### PR TITLE
Add custom filter to allow for inclusion in theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,38 @@ Screenshots
 
 ![Color Swatches](/images/swatches.png?raw=true)
 
+Including Within Theme
+===
+Take advantage of the `acf/swatch_settings/path` and `acf/swatch_settings/url` filters to modify where acf-swatch is located so that js and css are found correctly in the backend.
+
+```PHP
+/**
+ * Include ACF Color Swatch Field
+ */
+
+add_filter('acf/swatch_settings/path', 'my_swatch_path', 10, 1);
+
+function my_swatch_path( $path ) {
+  
+  $path = get_template_directory() . '/path/to/acf-swatch';
+  
+  return $path;
+  
+}
+
+add_filter('acf/swatch_settings/url', 'my_swatch_url', 10, 1);
+
+function my_swatch_url( $url ) {
+  
+  $url = get_template_directory_uri() . '/path/to/acf-swatch';
+  
+  return $url;
+  
+}
+
+include( 'path/to/acf-swatch.php' );
+```
+
 Changelog
 ===
 

--- a/acf-swatch-v5.php
+++ b/acf-swatch-v5.php
@@ -43,8 +43,8 @@ class acf_field_swatch extends acf_field
 		);
 		$this->settings = array(
 			'basename'	=> plugin_basename( __FILE__ ),
-			'path'		=> plugin_dir_path( __FILE__ ),
-			'url'		=> plugin_dir_url( __FILE__ ),
+			'path' 	 => apply_filters( 'acf/swatch_settings/path', plugin_dir_path( __FILE__ ) ),
+			'url'		=> apply_filters( 'acf/swatch_settings/url', plugin_dir_url( __FILE__ ) ),
 			'version'   => '1.0.0'
 		);
 


### PR DESCRIPTION
When I tried to include this plugin in a custom theme, I found that it was referring to the incorrect path for the js and css files in the backend. I've added two custom filters to enable users to override the default `plugin_dir_path()` and `plugin_dir_url()` that the plugin uses. 