### PR TITLE
Allow transparent values to be selected

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -3,7 +3,6 @@
 	function validTextColour(string) {
 		if (string === "") { return false; }
 		if (string === "inherit") { return false; }
-		if (string === "transparent") { return false; }
 
 		var image = document.createElement("img");
 		image.style.color = "rgb(0, 0, 0)";
@@ -22,7 +21,7 @@
 			var result;
 
 			// check if color statement is in shorthand syntax
-			if ( 'none' === val ) {
+			if ( 'none' === val || 'transparent' === val ) {
 				
 				result = 'transparent'; // not shorthand syntax, valid value
 
@@ -52,7 +51,7 @@
 						result = 'transparent'; // invalid color
 						$(this).attr('disabled', true).parent().addClass('disabled');
 					}
-					
+
 				}
 
 			} else {

--- a/js/input.js
+++ b/js/input.js
@@ -22,10 +22,14 @@
 			var result;
 
 			// check if color statement is in shorthand syntax
+			if ( 'none' === val ) {
+				
+				result = 'transparent'; // not shorthand syntax, valid value
 
-			if (val.indexOf('#') < 0 && val.indexOf('rgb') < 0 && val.indexOf('hsl') < 0) {
+			} else if (val.indexOf('#') < 0 && val.indexOf('rgb') < 0 && val.indexOf('hsl') < 0) {
 
 				if (val.indexOf('%') > -1) { // shorthand syntax for hsl
+					
 					if (val.split(',').length > 3) { // hsla confirmed
 						result = 'hsla(' + val + ')'; //hsla
 					} else {
@@ -33,18 +37,22 @@
 					}
 
 				} else if (val.split(',').length > 1) { // shorthand for either rgb or rgba
+					
 					if (val.split(',').length > 3) { // rgba confirmed
 						result = 'rgba(' + val + ')'; //rgba
 					} else {
 						result = 'rgb(' + val + ')'; //rgb
 					}
+
 				} else {
+					
 					if (validTextColour(val)) {
 						result = val; // color was already complete
 					} else {
 						result = 'transparent'; // invalid color
 						$(this).attr('disabled', true).parent().addClass('disabled');
 					}
+					
 				}
 
 			} else {


### PR DESCRIPTION
Adds support allowing `transparent` and `none` values to be selected in the interface.

These are valid values for `background-color` that a user could want to select and as such should be selectable and returnable from the plugin.

Currently, any choices using these values are marked as disabled and cannot be selected.