### PR TITLE
Match background-color syntax

### DIFF
--- a/acf-swatch-v5.php
+++ b/acf-swatch-v5.php
@@ -446,7 +446,20 @@ class acf_field_swatch extends acf_field
     */
     function format_value( $value, $post_id, $field ) {
 
-        return acf_get_field_type('select')->format_value( $value, $post_id, $field );
+		// Get label from choices field
+        $value = acf_get_field_type('select')->format_value( $value, $post_id, $field );
+
+        $map_to_transparent = array(
+        	'',
+        	'none'
+       	);
+
+        // Replace values which should be returned as transparent
+		if ( in_array( $value['value'], $map_to_transparent ) ) {
+			$value['value'] = 'transparent';
+		}
+
+		return $value;
 
     }
 

--- a/js/input.js
+++ b/js/input.js
@@ -53,7 +53,7 @@
 
 			var bg = result;
 
-			$(this).siblings('.swatch-toggle').children('.swatch-color').css('background', bg);
+			$(this).siblings('.swatch-toggle').children('.swatch-color').css('background-color', bg);
 		});
 	}
 


### PR DESCRIPTION
`` (blank string) and `none` aren't valid values for `background-color` and should be mapped to `transparent` when the plugin returns a selected value.

Additionally, using the `background` property to set the swatch color, in the admin interface, also resets all other background properties. This is unnecessary and should use the `background-color` longhand instead to avoid overriding other values, possibly set by extension plugins.